### PR TITLE
Fix Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .test
 build/
+dist/
 *~
 /tracking-api
 /vendor/*/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN make
 
 FROM alpine:3.7
 EXPOSE 8080
-COPY --from=build /go/src/github.com/segmentio/tracking-api-chaos/tracking-api-chaos /
+ARG VERSION
+COPY --from=build /go/src/github.com/segmentio/tracking-api-chaos/dist/tracking-api-chaos-${VERSION}-linux-amd64 /tracking-api-chaos
 RUN chmod +x /tracking-api-chaos
 ENTRYPOINT ["/tracking-api-chaos"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10-alpine as build
-RUN apk add --no-cache git make
+RUN apk add --no-cache git build-base 
 RUN mkdir -p /go/src/github.com/segmentio/tracking-api-chaos/vendor
 COPY ./vendor/vendor.json /go/src/github.com/segmentio/tracking-api-chaos/vendor/vendor.json
 WORKDIR /go/src/github.com/segmentio/tracking-api-chaos

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
 DOCKER_TAG := "tracking-api-chaos:$(VERSION)"
 
+all: dist/tracking-api-chaos-$(VERSION)-darwin-amd64 dist/tracking-api-chaos-$(VERSION)-linux-amd64
+
 test: | govendor
 	govendor sync
 	govendor test -cover -v +local
-
-all: dist/tracking-api-chaos-$(VERSION)-darwin-amd64 dist/tracking-api-chaos-$(VERSION)-linux-amd64
 
 clean:
 	rm -rf ./dist

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 	rm -rf ./dist
 
 docker:
-	docker build -f Dockerfile -t $(DOCKER_TAG) .
+	docker build -f Dockerfile -t $(DOCKER_TAG) --build-arg VERSION=$(VERSION) .
 
 dist/:
 	mkdir -p dist

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_TAG := "tracking-api-chaos:$(VERSION)"
 
 test: | govendor
 	govendor sync
-	govendor test -race -cover -v +local
+	govendor test -cover -v +local
 
 all: dist/tracking-api-chaos-$(VERSION)-darwin-amd64 dist/tracking-api-chaos-$(VERSION)-linux-amd64
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tracking-api-chaos[69277]: - [::1]:3000->[::1]:51124 - localhost:3000 - POST /v1
 You can also use Docker:
 
 ```sh
-% docker build -t tracking-api-chaos .
+% make docker 
 
 % echo '[{weight: 10, statusCode: {code: 500}}]' | docker run -i -p 8080:8080 tracking-api-chaos -chaos -
 ```


### PR DESCRIPTION
I tried to build using the instruction but it failed, so here's an attempt at fixing it:

- `gcc` was missing in Docker, fixed by adding `build-base` in the packages
- `-race` doesn't work with alpine, fixed by removing it
- `make` doesn't run `all`, not sure if this was intended
- the executable `./tracking-api-chaos` doesn't exist, fixed by adding `VERSION` build arg and copying using it