### PR TITLE
Fix 2 typos

### DIFF
--- a/test/server_test.go
+++ b/test/server_test.go
@@ -1,5 +1,5 @@
 // Tests are generally an HTTP call followed by validation of:
-// - the repsonse
+// - the response
 // - the server posting a message.Message
 package test
 

--- a/tracking-api-chaos.go
+++ b/tracking-api-chaos.go
@@ -135,7 +135,7 @@ func main() {
 		wg.Wait()
 	default:
 		exitCode = 1
-		events.Log("an error occured serving requests: %{error}v", err)
+		events.Log("an error occurred serving requests: %{error}v", err)
 	}
 
 	os.Exit(exitCode)


### PR DESCRIPTION
Fix 2 typos from `misspell`:
```
tracking-api-chaos.go:138:23: "occured" is a misspelling of "occurred"
test/server_test.go:2:9: "repsonse" is a misspelling of "response"
```